### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accepted-proposal.md
+++ b/.github/ISSUE_TEMPLATE/accepted-proposal.md
@@ -4,6 +4,7 @@ about: 'This template is reserved for StudioCMS maintainers only.'
 title: ''
 labels: 'Accepted proposal'
 assignees: ''
+type: 'RFC Stage 2'
 ---
 
 <!-- 

--- a/.github/ISSUE_TEMPLATE/import-existing-project.md
+++ b/.github/ISSUE_TEMPLATE/import-existing-project.md
@@ -4,6 +4,7 @@ about: 'This template is used for those who wish to import an existing project/r
 title: ''
 labels: ''
 assignees: ''
+type: 'RFC Stage 1'
 ---
 
 <!-- 


### PR DESCRIPTION
This pull request includes updates to the issue templates in the `.github/ISSUE_TEMPLATE` directory. The changes involve adding a `type` field to specify the RFC stage for different templates.

Updates to issue templates:

* [`.github/ISSUE_TEMPLATE/accepted-proposal.md`](diffhunk://#diff-3963de536bc14127a0715470f28d0fa79e2f99f1a7b9e7c23fba19a3931323eeR7): Added `type: 'RFC Stage 2'` to indicate the proposal is at RFC Stage 2.
* [`.github/ISSUE_TEMPLATE/import-existing-project.md`](diffhunk://#diff-e746d8abbf6a038179d3c6aff3170a38c096118a9daa2cae12186ae9f94278b7R7): Added `type: 'RFC Stage 1'` to indicate the proposal is at RFC Stage 1.